### PR TITLE
Changed the order of request, response and sample

### DIFF
--- a/templates/operation.mustache
+++ b/templates/operation.mustache
@@ -33,6 +33,14 @@
                 <code class="bash">{{httpMethod}} {{basePath}}{{path}}</code>
             {{/vendorExtensions.x-wso2-request}}
 
+            <h4 class="section-heading">Sample CURL</h4>
+            {{#vendorExtensions.x-wso2-curl}}
+                <div class="pre"><code class="bash">{{vendorExtensions.x-wso2-curl}}</code></div>
+            {{/vendorExtensions.x-wso2-curl}}
+            {{^vendorExtensions.x-wso2-curl}}
+                <p>Not Available</p>
+            {{/vendorExtensions.x-wso2-curl}}
+            
             <div class="pointer" data-toggle="collapse" data-target="#response-{{operationId}}">
                 <h4 class="section-heading">
                     Response
@@ -47,14 +55,6 @@
             {{^vendorExtensions.x-wso2-response}}
                 <p>Not Available</p>
             {{/vendorExtensions.x-wso2-response}}
-
-            <h4 class="section-heading">Sample CURL</h4>
-            {{#vendorExtensions.x-wso2-curl}}
-                <div class="pre"><code class="bash">{{vendorExtensions.x-wso2-curl}}</code></div>
-            {{/vendorExtensions.x-wso2-curl}}
-            {{^vendorExtensions.x-wso2-curl}}
-                <p>Not Available</p>
-            {{/vendorExtensions.x-wso2-curl}}
 
             <h4 class="section-heading" id="scroll-to">Parameters</h4>
             <table class="table table-hover">


### PR DESCRIPTION
Currently, the swagger doc is generated with API details appearing in this order - 1.Request 2. Response 3. Sample Curl. 
Changed this so that it is generated in the following order - 1.Request 2. Sample Curl 3. Response