### PR TITLE
Fix swagger generation fail issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
             <plugin>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-codegen-maven-plugin</artifactId>
+                <version>2.4.1</version>     
                 <executions>
                     <execution>
                         <phase>site</phase>


### PR DESCRIPTION
Downgrade swagger-codegen-maven-plugin - The tool was using 3.0.0-rc1 version of the plugin which causes an error.